### PR TITLE
Add blue line detection and switching logic

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -12,9 +12,10 @@ The package exposes a single node `NavigatorNode` that converts camera images in
    Select the blob whose center is closest to the previously detected line
    position (or the image center if none is available).
 3. Each scan line is also checked for blue pixels using HSV thresholding.
-   When a sufficient number of lines contain blue over consecutive frames,
-   the follower switches between the leftmost and rightmost line and locks
-   this choice for several frames.
+   When enough lines contain blue over consecutive frames, the node enters a
+   "blue detected" state.
+   It waits until multiple blobs appear on the black line before switching the
+   main line and locking this choice for several frames.
 4. Calculate the weighted deviation of these center positions from the image center.
 5. Convert this deviation into an angular velocity using a proportional gain.
    The linear velocity is scaled using the current angular velocity and
@@ -34,6 +35,8 @@ The package exposes a single node `NavigatorNode` that converts camera images in
 - `blue_scanlines_required`: number of scan lines that must detect blue in one frame.
 - `blue_detect_frames_threshold`: consecutive frame count to confirm a branch.
 - `main_line_lock_duration`: frames to lock the selected line after switching.
+- `multi_blob_scanlines_required`: scan lines with multiple blobs needed to
+  confirm a branch.
 
 The node retrieves the image width and height from each received frame, so it can adapt to different camera resolutions.
 

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -11,11 +11,15 @@ The package exposes a single node `NavigatorNode` that converts camera images in
 2. For each predefined scan line, detect connected white pixel blobs.
    Select the blob whose center is closest to the previously detected line
    position (or the image center if none is available).
-3. Calculate the weighted deviation of these center positions from the image center.
-4. Convert this deviation into an angular velocity using a proportional gain.
+3. Each scan line is also checked for blue pixels using HSV thresholding.
+   When a sufficient number of lines contain blue over consecutive frames,
+   the follower switches between the leftmost and rightmost line and locks
+   this choice for several frames.
+4. Calculate the weighted deviation of these center positions from the image center.
+5. Convert this deviation into an angular velocity using a proportional gain.
    The linear velocity is scaled using the current angular velocity and
    smoothed by a low-pass filter.
-5. Publish the resulting `Twist`.
+6. Publish the resulting `Twist`.
 
 ## Parameters
 - `scan_lines`: list of normalized y positions (ratio of image height) used for line detection.
@@ -26,6 +30,10 @@ The package exposes a single node `NavigatorNode` that converts camera images in
 - `max_angular`: maximum angular velocity.
 - `alpha`: coefficient for the low-pass filter used on linear velocity.
 - `debug`: enable OpenCV visualization when set to `true`.
+- `blue_lower` / `blue_upper`: HSV range used for blue detection.
+- `blue_scanlines_required`: number of scan lines that must detect blue in one frame.
+- `blue_detect_frames_threshold`: consecutive frame count to confirm a branch.
+- `main_line_lock_duration`: frames to lock the selected line after switching.
 
 The node retrieves the image width and height from each received frame, so it can adapt to different camera resolutions.
 

--- a/etrobo_navigator/etrobo_navigator.py
+++ b/etrobo_navigator/etrobo_navigator.py
@@ -91,7 +91,7 @@ class NavigatorNode(Node):
         for ratio, w in zip(self.scan_lines, self.weights):
             y = int(ratio * height)
             row = binary[y, :]
-            hsv_row = hsv[y, :]
+            hsv_row = hsv[y:y + 1, :]
             if np.any(cv2.inRange(hsv_row, self.blue_lower, self.blue_upper)):
                 blue_scan_count += 1
 

--- a/etrobo_navigator/etrobo_navigator.py
+++ b/etrobo_navigator/etrobo_navigator.py
@@ -43,11 +43,11 @@ class NavigatorNode(Node):
         self.declare_parameter('blue_scanlines_required', 2)
         self.declare_parameter('blue_detect_frames_threshold', 3)
         self.declare_parameter('main_line_lock_duration', 10)
-        self.blue_lower = np.array(
-            self.get_parameter('blue_lower').value, dtype=np.uint8
+        self.blue_lower = tuple(
+            int(v) for v in self.get_parameter('blue_lower').value
         )
-        self.blue_upper = np.array(
-            self.get_parameter('blue_upper').value, dtype=np.uint8
+        self.blue_upper = tuple(
+            int(v) for v in self.get_parameter('blue_upper').value
         )
         self.blue_scanlines_required = self.get_parameter(
             'blue_scanlines_required'


### PR DESCRIPTION
## Requirement
Add blue line detection and main line switching logic to the `etrobo_navigator.py` node.

Requirements:

1. Blue line detection:
   - Use HSV thresholding to detect blue color in each scanline.
   - Define HSV range for blue (e.g., H:100–130, S:100–255, V:50–255).
   - If blue is detected on N or more scanlines (parameterized), consider it a branching point.

2. Switching main line:
   - If a branching point is detected and the robot is currently following the leftmost line, switch to the rightmost line (or vice versa).
   - This main line switch should be done only once per branching event.

3. Stability and duration settings (parameterized):
   - Use a parameter `blue_detect_frames_threshold` (e.g., 3) to define how many consecutive frames with blue detection are required to confirm a branch.
   - After switching, maintain the new main line for a parameterized number of frames (`main_line_lock_duration`) to prevent immediate reversion or oscillation.

4. Safety:
   - Ensure switching logic does not interfere with existing line-following and scanline weighting logic.
   - Add debug print statements or on-screen annotations (if debug mode is enabled) showing:
     - Blue detection count
     - Main line switching status
     - Remaining lock duration

5. Parameter placement:
   - All parameters (`blue HSV range`, `blue_detect_frames_threshold`, `main_line_lock_duration`) should be configurable as class variables or loaded via ROS parameters.

## Summary
- Implement blue color detection across scan lines using HSV masks
- Switch between left and right lines when consecutive blue detections exceed the threshold
- Lock the new main line for a configurable duration to avoid oscillation
- Provide new ROS parameters for blue detection and lock settings
- Display blue detection information and lock status in debug view
- Document the updated behavior and parameters in `DESIGN.md`

## Testing
- `python -m py_compile etrobo_navigator/etrobo_navigator.py`
- `colcon test --packages-select etrobo_simulator` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c433d79a8832fbe90a9df0fee63b2