### PR TITLE
Update state machine logic

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -14,11 +14,12 @@ The package exposes a single node `NavigatorNode` that converts camera images in
    When the state machine transitions from `blue_detected` to `blue_to_black`,
    blobs narrower than `MIN_BLOB_WIDTH` (5 px) are ignored and the remaining
    blobs are ranked by distance to the previous center (ties prefer the right
-   blob). The first scan line to select a branch enters a terminal `branched`
-   state and its center is not used for averaging. The chosen center overrides
-   all scan lines for that frame and lines whose detected blob is farther than
-   `BRANCH_CX_TOL` (25 px) adopt this branch center. Each scan line also tracks
-   a small state machine to report if a blue area temporarily occludes the line.
+   blob). If a valid blob is chosen, the scan line immediately returns to
+   `normal` and the selected center overrides all scan lines for that frame.
+   Lines whose detected blob is farther than `BRANCH_CX_TOL` (25 px) adopt this
+   branch center. Each scan line tracks a small state machine (`normal`,
+   `blue_detected`, `blue_to_black`) to report if a blue area temporarily
+   occludes the line.
 3. Calculate the weighted deviation of these center positions from the image center.
 4. Convert this deviation into an angular velocity using a proportional gain.
    The linear velocity is scaled using the current angular velocity and

--- a/etrobo_navigator/etrobo_navigator.py
+++ b/etrobo_navigator/etrobo_navigator.py
@@ -98,12 +98,6 @@ class NavigatorNode(Node):
 
             transitioned = prev_state != "blue_to_black" and state == "blue_to_black"
 
-            # Skip processing after branching
-            if state == "branched":
-                debug_info.append((y, branch_cx, state, blue_count, blue_ratio))
-                self.sl_state[i] = state
-                continue
-
             if len(indices) > 0:
                 # Split indices into connected components
                 splits = np.where(np.diff(indices) > 1)[0] + 1
@@ -127,15 +121,12 @@ class NavigatorNode(Node):
                         )[0]
                         branch_cx = chosen_cx
                         target_cx = branch_cx
-                        state = "branched"
                         cx_list = [(branch_cx, w_prev) for (_, w_prev) in cx_list]
                         debug_info = [
                             (info[0], branch_cx, info[2], info[3], info[4])
                             for info in debug_info
                         ]
-                        debug_info.append((y, chosen_cx, state, blue_count, blue_ratio))
-                        self.sl_state[i] = state
-                        continue
+                        state = "normal"
                     else:
                         state = "normal"
 


### PR DESCRIPTION
## Requirement
Specification update for NavigatorNode – state machine correction
-----------------------------------------------------------------

• The per-scanline finite-state machine must use ONLY the following
  states:  "normal", "blue_detected", "blue_to_black".

• When a scan-line first enters "blue_to_black" **and** successfully
  selects a branch (i.e. a valid blob wider than MIN_BLOB_WIDTH is
  chosen), that scan-line must transition immediately back to
  **"normal"**.  No additional terminal state such as "branched" is
  allowed.

• After the transition to "normal":
    – that scan-line continues to contribute its chosen_cx to the
      deviation calculation in all later frames;
    – it is allowed to re-enter "blue_detected" and "blue_to_black"
      during future blue-line events.

• Any existing checks or code paths that depend on a "branched" state
  must be removed.  In particular, do not short-circuit processing with
  `if state == "branched": continue`.

• All other behaviour (blue detection thresholds, branch_cx forcing,
  PID/velocity computations, debug overlay) remains unchanged.

## Summary
- remove the obsolete `branched` state in `NavigatorNode`
- let scan lines return to `normal` immediately after branch selection
- update design documentation to describe the new state machine

## Testing
- `colcon test --packages-select etrobo_simulator` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68703a6d601c832fb7cc48a1353912a1