### PR TITLE
Update center handling during blue detection

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -17,9 +17,11 @@ The package exposes a single node `NavigatorNode` that converts camera images in
    blob). If a valid blob is chosen, the scan line immediately returns to
    `normal` and the selected center overrides all scan lines for that frame.
    Lines whose detected blob is farther than `BRANCH_CX_TOL` (25 px) adopt this
-   branch center. Each scan line tracks a small state machine (`normal`,
-   `blue_detected`, `blue_to_black`) to report if a blue area temporarily
-   occludes the line.
+   branch center. While a scan line is in `blue_detected` or `blue_to_black`,
+   its chosen center immediately replaces the reference center for the next
+   lines so the blob ranking relies on the latest estimate. Each scan line
+   tracks a small state machine (`normal`, `blue_detected`, `blue_to_black`)
+   to report if a blue area temporarily occludes the line.
 3. Calculate the weighted deviation of these center positions from the image center.
 4. Convert this deviation into an angular velocity using a proportional gain.
    The linear velocity is scaled using the current angular velocity and

--- a/etrobo_navigator/etrobo_navigator.py
+++ b/etrobo_navigator/etrobo_navigator.py
@@ -112,6 +112,10 @@ class NavigatorNode(Node):
 
                 chosen_cx, _ = min(candidates, key=lambda c: abs(c[0] - target_cx))
 
+                if state in ("blue_detected", "blue_to_black") and branch_cx is None:
+                    base_cx = chosen_cx
+                    target_cx = base_cx
+
                 if transitioned and branch_cx is None:
                     valid = [c for c in candidates if c[1] >= self.MIN_BLOB_WIDTH]
                     if valid:


### PR DESCRIPTION
## Requirement
Current behavior
----------------
After a blue line is detected and the scan-line state transitions through
"blue_detected" → "blue_to_black", the robot often reverts to the left
branch.  Investigation shows that during these two states the code keeps
using the old line center (prev_cx / base_cx) that still points to the
left track.  Consequently, when the split is evaluated, the distance test
selects the left blob as “closer”, defeating the intended right-branch
logic.

What we need
------------
• While a scan-line is in either "blue_detected" **or** "blue_to_black",
  its most-recently chosen center (chosen_cx) must immediately replace the
  reference center used for subsequent distance calculations.

• In practical terms:  
  – Update the variable that represents the “current line center” every
    frame, even before the branch decision is final.  
  – Ensure the blob-ranking step compares candidate blobs to this updated
    center, not to an older value.

Expected outcome
----------------
With the reference center continuously refreshed, both left and right
branches of the upcoming split appear at similar distance, allowing the
right-side tie-break rule (larger x wins) to work correctly.  After the
transition back to "normal", the robot should stay on the right branch.

## Summary
- refresh the reference center when a scan line is in `blue_detected` or `blue_to_black`
- document the new behavior in DESIGN.md

## Testing
- `colcon test --packages-select etrobo_simulator` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68703e17c5e8832fad28a8680189af9b