### PR TITLE
Implement continuous branch check

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -11,17 +11,20 @@ The package exposes a single node `NavigatorNode` that converts camera images in
 2. For each predefined scan line, detect connected white pixel blobs.
    Select the blob whose center is closest to the previously detected line
    position (or the image center if none is available).
-   When the state machine transitions from `blue_detected` to `blue_to_black`,
-   blobs narrower than `MIN_BLOB_WIDTH` (5 px) are ignored and the remaining
-   blobs are ranked by distance to the previous center (ties prefer the right
-   blob). If a valid blob is chosen, the scan line immediately returns to
-   `normal` and the selected center overrides all scan lines for that frame.
-   Lines whose detected blob is farther than `BRANCH_CX_TOL` (25 px) adopt this
-   branch center. While a scan line is in `blue_detected` or `blue_to_black`,
-   its chosen center immediately replaces the reference center for the next
-   lines so the blob ranking relies on the latest estimate. Each scan line
-   tracks a small state machine (`normal`, `blue_detected`, `blue_to_black`)
-   to report if a blue area temporarily occludes the line.
+    While a scan line is in `blue_to_black`, each frame checks all detected
+    blobs to determine if a right-hand branch exists. A branch decision
+    requires at least two blobs. Blobs narrower than `MIN_BLOB_WIDTH` (5 px)
+    are ignored and the remaining blobs are ranked by distance to the previous
+    center (ties prefer the right blob). When a valid branch is chosen, the
+    scan line immediately returns to `normal` and the selected center overrides
+    all scan lines for that frame. If no branch is found, the scan line stays
+    in `blue_to_black` and will be checked again on the next frame. Lines whose
+    detected blob is farther than `BRANCH_CX_TOL` (25 px) adopt this branch
+    center. While a scan line is in `blue_detected` or `blue_to_black`, its
+    chosen center immediately replaces the reference center for the next lines
+    so the blob ranking relies on the latest estimate. Each scan line tracks a
+    small state machine (`normal`, `blue_detected`, `blue_to_black`) to report
+    if a blue area temporarily occludes the line.
 3. Calculate the weighted deviation of these center positions from the image center.
 4. Convert this deviation into an angular velocity using a proportional gain.
    The linear velocity is scaled using the current angular velocity and

--- a/etrobo_navigator/etrobo_navigator.py
+++ b/etrobo_navigator/etrobo_navigator.py
@@ -96,7 +96,7 @@ class NavigatorNode(Node):
                 if not blue_present and black_present:
                     state = "blue_to_black"
 
-            transitioned = prev_state != "blue_to_black" and state == "blue_to_black"
+            # Continuously check for a branch while in blue_to_black
 
             if len(indices) > 0:
                 # Split indices into connected components
@@ -116,23 +116,22 @@ class NavigatorNode(Node):
                     base_cx = chosen_cx
                     target_cx = base_cx
 
-                if transitioned and branch_cx is None:
-                    valid = [c for c in candidates if c[1] >= self.MIN_BLOB_WIDTH]
-                    if valid:
-                        chosen_cx, _ = sorted(
-                            valid,
-                            key=lambda c: (abs(c[0] - base_cx), -c[0])
-                        )[0]
-                        branch_cx = chosen_cx
-                        target_cx = branch_cx
-                        cx_list = [(branch_cx, w_prev) for (_, w_prev) in cx_list]
-                        debug_info = [
-                            (info[0], branch_cx, info[2], info[3], info[4])
-                            for info in debug_info
-                        ]
-                        state = "normal"
-                    else:
-                        state = "normal"
+                if state == "blue_to_black" and branch_cx is None:
+                    if len(blobs) >= 2:
+                        valid = [c for c in candidates if c[1] >= self.MIN_BLOB_WIDTH]
+                        if valid:
+                            chosen_cx, _ = sorted(
+                                valid,
+                                key=lambda c: (abs(c[0] - base_cx), -c[0])
+                            )[0]
+                            branch_cx = chosen_cx
+                            target_cx = branch_cx
+                            cx_list = [(branch_cx, w_prev) for (_, w_prev) in cx_list]
+                            debug_info = [
+                                (info[0], branch_cx, info[2], info[3], info[4])
+                                for info in debug_info
+                            ]
+                            state = "normal"
 
                 if branch_cx is not None and abs(chosen_cx - branch_cx) > self.BRANCH_CX_TOL:
                     chosen_cx = branch_cx


### PR DESCRIPTION
## Requirement
Specification update – continuous branch check in "blue_to_black"
-----------------------------------------------------------------
While a scan-line remains in the **"blue_to_black"** state, the program must
*continuously* (every frame) inspect the current blobs and, if a valid
right-hand branch appears, switch to it.  Do not limit the decision to the
first transition frame.

Required behaviour
------------------
1. For each scan-line whose state is **exactly "blue_to_black"**, run the
   branch-selection logic on **every frame** until the line returns to
   "normal".

2. A valid branch decision is the same as before:
   • at least two blobs,  
   • choose the blob wider than MIN_BLOB_WIDTH that is closest to the
     current `base_cx` (tie-break: larger x ⇒ right side).

3. Once a branch is chosen for that scan-line:
   • update `branch_cx`, `target_cx`, and `self.prev_cx` as today;  
   • immediately set the scan-line state back to **"normal"** so it will
     participate in standard tracking next frame.

4. If no valid branch is present in a given frame, keep the scan-line in
   "blue_to_black" and try again on the next frame.

5. Remove the `transitioned` guard; the branch check must rely solely on
   the scan-line being in "blue_to_black".

## Summary
- remove one-time transition check and search for branches every frame while in `blue_to_black`
- keep a scan line in `blue_to_black` when no branch is found
- document the updated branch selection logic

## Testing
- `python -m py_compile etrobo_navigator/etrobo_navigator.py`
- `colcon test --packages-select etrobo_simulator` *(fails: command not found)*
- `pytest -k flake8` *(fails due to missing ament_flake8)*

------
https://chatgpt.com/codex/tasks/task_e_6871c9f5739c832fba4c4261521a70e5