### PR TITLE
Improve branch selection window

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -14,13 +14,14 @@ The package exposes a single node `NavigatorNode` that converts camera images in
     While a scan line is in `blue_to_black`, each frame checks all detected
     blobs to determine if a right-hand branch exists. A branch decision
     requires at least two blobs. Blobs narrower than `MIN_BLOB_WIDTH` (5 px)
-    are ignored and the remaining blobs are ranked by distance to the previous
-    center (ties prefer the right blob). When a valid branch is chosen, the
-    scan line immediately returns to `normal` and the selected center overrides
-    all scan lines for that frame. If no branch is found, the scan line stays
-    in `blue_to_black` and will be checked again on the next frame. Lines whose
-    detected blob is farther than `BRANCH_CX_TOL` (25 px) adopt this branch
-    center. While a scan line is in `blue_detected` or `blue_to_black`, its
+    are ignored. Those within `BRANCH_WINDOW` (40 px) of the previous center
+    are considered and the right-most among them is chosen. If no candidate
+    falls inside the window, the closest blob to the previous center is used.
+    When a valid branch is chosen, the scan line immediately returns to
+    `normal` and the selected center overrides all scan lines for that frame.
+    Lines whose detected blob is farther than `BRANCH_CX_TOL` (25 px) adopt
+    this branch center. While a scan line is in `blue_detected` or
+    `blue_to_black`, its
     chosen center immediately replaces the reference center for the next lines
     so the blob ranking relies on the latest estimate. Each scan line tracks a
     small state machine (`normal`, `blue_detected`, `blue_to_black`) to report


### PR DESCRIPTION
## Requirement
```
Please refine the branch-selection logic so it only chooses a blob that is
both:

  • close to the current line (within a distance window) **and**
  • the right-most among those close blobs.

Requirements
------------

1. Add a class constant  
       BRANCH_WINDOW = 40   # pixels (tune if needed)

2. When state == "blue_to_black" and branch_cx is still None, compute:

       near = [c for c in candidates
               if abs(c[0] - base_cx) <= self.BRANCH_WINDOW
               and c[1] >= self.MIN_BLOB_WIDTH]

3. Selection logic:

   • If `near` is not empty  
         chosen_cx, _ = max(near, key=lambda c: c[0])   # right-most in window  
     (this becomes the new branch_cx, target_cx, etc.)

   • Else (no blob within the window)  
         chosen_cx, _ = min(candidates,
                            key=lambda c: abs(c[0] - base_cx))  
     — same fallback as today.

4. After choosing `chosen_cx` as a branch, immediately set
       state = "normal"
   so the scan-line resumes normal tracking next frame.

Do not change any other thresholds, PID/velocity logic, or debug output.
```

## Summary
- add `BRANCH_WINDOW` constant to `NavigatorNode`
- refine branch selection to favor the right-most blob within the new window
- update design documentation for the new algorithm

## Testing
- `colcon test --packages-select etrobo_simulator` *(fails: `colcon` not found)*


------
https://chatgpt.com/codex/tasks/task_e_6871e2feeb54832f89a81dda2b62bcd7