### PR TITLE
Adjust scan lines for 20° camera tilt angle

### DIFF
--- a/etrobo_navigator/etrobo_navigator.py
+++ b/etrobo_navigator/etrobo_navigator.py
@@ -94,9 +94,9 @@ class NavigatorNode(Node):
 
         # --- Parameters ---
         # Normalized y-positions of scan lines (0.0 = top, 1.0 = bottom)
-        # 6 scan lines for detection
+        # 6 scan lines for detection (adjusted for 20° camera tilt angle, down from 30°)
         self.scan_lines = [
-            0.625, 0.666, 0.708, 0.75, 0.791, 0.833
+            0.775, 0.816, 0.858, 0.9, 0.941, 0.983
         ]
         # Weights biased toward the lower part of the image (sum to 1.0)
         self.weights = [


### PR DESCRIPTION
## Summary
- Updated scan_lines to compensate for camera tilt angle change from 30° to 20°
- Changed scan line positions from [0.625, 0.666, 0.708, 0.75, 0.791, 0.833] to [0.775, 0.816, 0.858, 0.9, 0.941, 0.983]
- Ensures same road detection behavior as before the camera angle adjustment

## Test plan
- [x] Test line following behavior with new scan line positions
- [ ] Verify branch detection functionality
- [ ] Confirm robot maintains stable navigation

🤖 Generated with [Claude Code](https://claude.ai/code)